### PR TITLE
Added ability to stop the koa-service as a gulp task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 npm-debug.log
+
+.idea

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ gulp.task('server', ['build'], function() {
             .pipe(service('./build/server.js', { env: { NODE_ENV: 'development', DEBUG: '*' }}));
     });
 });
+
+gulp.task('stop', function(){
+    // Stops a server (by pid)
+    service.stop('./build/server.js');
+});
 ```
 
 [0]: http://gulpjs.com

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "debug": "^2.2.0",
     "deepmerge": "^0.2.10",
     "gulp-util": "^3.0.6",
+    "mkdirp": "^0.5.1",
+    "os-tmpdir": "^1.0.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-koa",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Koa dev service (based on gulp-koa-service by CoLee <5969226@qq.com>)",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,49 +1,49 @@
 var through = require('through2'),
-	gutil = require('gulp-util'),
-	merge = require('deepmerge'),
-	PluginError = gutil.PluginError,
-	spawn = require('child_process').spawn,
-	debug = require('debug')('gulp-koa'),
-	fs = require('fs'),
-	path = require('path'),
-	info = gutil.colors.cyan,
-	error = gutil.colors.bold.red,
-	dbg = gutil.colors.gray,
-	server = null;
+    gutil = require('gulp-util'),
+    merge = require('deepmerge'),
+    PluginError = gutil.PluginError,
+    spawn = require('child_process').spawn,
+    debug = require('debug')('gulp-koa'),
+    fs = require('fs'),
+    path = require('path'),
+    info = gutil.colors.cyan,
+    error = gutil.colors.bold.red,
+    dbg = gutil.colors.gray,
+    server = null;
 
 
-function stop(){
-	if (server && server.kill) {
-		debug(info('Server is already running: ') + dbg(server.pid || 0));
-		server.kill('SIGTERM');
-		server = null;
-	}
+function stop() {
+    if (server && server.kill) {
+        debug(info('Server is already running: ') + dbg(server.pid || 0));
+        server.kill('SIGTERM');
+        server = null;
+    }
 }
 
-module.exports = function(script, options) {
-	if (!script || typeof(script) !== "string") {
-		debug(error('No script file passed or script is not a string'))
-		throw new PluginError('gulp-koa', 'Missing or invalid script for gulp-koa', {showProperties: false});
-	}
-	fs.exists(script, function(exists) {
-		if (!exists) {
-			debug(error('Script file does not exist. ') + dbg(script));
-			throw new PluginError('gulp-koa', 'Script file does not exist (' + info(script) + ')', {showProperties: false});
-		}
-	});
-	options = options || {};
-	var opts = merge({
-		cwd: undefined,
-		env: process.env,
-		stdio: 'inherit'
-	}, options);
-	return through.obj(function() {
-		stop();
-		
-		debug(info('Spawning new server with: ' + script));
+module.exports = function (script, options) {
+    if (!script || typeof(script) !== "string") {
+        debug(error('No script file passed or script is not a string'))
+        throw new PluginError('gulp-koa', 'Missing or invalid script for gulp-koa', {showProperties: false});
+    }
+    fs.exists(script, function (exists) {
+        if (!exists) {
+            debug(error('Script file does not exist. ') + dbg(script));
+            throw new PluginError('gulp-koa', 'Script file does not exist (' + info(script) + ')', {showProperties: false});
+        }
+    });
+    options = options || {};
+    var opts = merge({
+        cwd: undefined,
+        env: process.env,
+        stdio: 'inherit'
+    }, options);
+    return through.obj(function () {
+        stop();
 
-		server = spawn('node', ['--harmony', script], opts);
-	});
+        debug(info('Spawning new server with: ' + script));
+
+        server = spawn('node', ['--harmony', script], opts);
+    });
 }
 
 module.exports.stop = stop;

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ module.exports = function (script, options) {
         debug(info('Spawning new server with: ' + script));
         server = spawn('node', ['--harmony', script], opts);
         var pidPath = getPidPathFor(script);
+        mkdirp.sync(path.dirname(pidPath));
         fs.writeFileSync(pidPath, server.pid.toString());
         console.log('write pid ' + server.pid + ' to ' + pidPath);
         server.on('exit', function(code){

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ var through = require('through2'),
     spawn = require('child_process').spawn,
     debug = require('debug')('gulp-koa'),
     fs = require('fs'),
+    tmpdir = require('os-tmpdir')(),
+    mkdirp = require('mkdirp'),
     path = require('path'),
     info = gutil.colors.cyan,
     error = gutil.colors.bold.red,
@@ -12,12 +14,23 @@ var through = require('through2'),
     server = null;
 
 
-function stop() {
+function stop(script) {
     if (server && server.kill) {
         debug(info('Server is already running: ') + dbg(server.pid || 0));
         server.kill('SIGTERM');
         server = null;
+    } else if (!server) {
+        var pidPath = getPidPathFor(script);
+        if(fs.existsSync(pidPath)){
+            var pid = fs.readFileSync(pidPath, 'utf8') | 0; //read pid and convert it to int
+            console.log('send SIGTERM to pid ' + pid);
+            process.kill(pid);
+        };
     }
+}
+
+function getPidPathFor(script) {
+    return path.join(tmpdir, 'gulp-koa', path.dirname(script), path.basename(script) + ".pid");
 }
 
 module.exports = function (script, options) {
@@ -38,11 +51,16 @@ module.exports = function (script, options) {
         stdio: 'inherit'
     }, options);
     return through.obj(function () {
-        stop();
-
+        stop(script);
         debug(info('Spawning new server with: ' + script));
-
         server = spawn('node', ['--harmony', script], opts);
+        var pidPath = getPidPathFor(script);
+        fs.writeFileSync(pidPath, server.pid.toString());
+        console.log('write pid ' + server.pid + ' to ' + pidPath);
+        server.on('exit', function(code){
+            console.log('Koa has stopped with exit code ' + code);
+            fs.unlinkSync(pidPath);
+        });
     });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,13 @@ var through = require('through2'),
 	server = null;
 
 
+function stop(){
+	if (server && server.kill) {
+		debug(info('Server is already running: ') + dbg(server.pid || 0));
+		server.kill('SIGTERM');
+		server = null;
+	}
+}
 
 module.exports = function(script, options) {
 	if (!script || typeof(script) !== "string") {
@@ -31,14 +38,12 @@ module.exports = function(script, options) {
 		stdio: 'inherit'
 	}, options);
 	return through.obj(function() {
-		if (server && server.kill) {
-			debug(info('Server is already running: ') + dbg(server.pid || 0));
-			server.kill('SIGTERM');
-			server = null;
-		}
+		stop();
 		
 		debug(info('Spawning new server with: ' + script));
 
 		server = spawn('node', ['--harmony', script], opts);
 	});
 }
+
+module.exports.stop = stop;


### PR DESCRIPTION
When koa-service starts, the PID of the server is persisted in temporary directory (cross-platform). This gives an ability to stop it later.
